### PR TITLE
Fixed anonymous auth

### DIFF
--- a/asyauth/common/credentials/__init__.py
+++ b/asyauth/common/credentials/__init__.py
@@ -77,6 +77,10 @@ class UniCredential:
 				username = url_e.username
 		
 		secret = url_e.password
+		
+		if secret is None and username is None:
+			protocol = asyauthProtocol.NONE
+
 		credobj = None
 		if protocol == asyauthProtocol.KERBEROS:
 			from asyauth.common.credentials.kerberos import KerberosCredential


### PR DESCRIPTION
Hello,

Connection URL such as `rdp+ntlm-password://IP`, were working with version `0.0.8` of `aardwolf` but they aren't working now with the latest version.

I'm not sure but I think it's because the logic for anonymous authentication was not ported to this new `asysauth` library.

## Actual behaviour:
Using this URL connection `rdp+ntlm-password://IP` I receive:
```
File "/root/.cache/pypoetry/virtualenvs/crackmapexec-Lq1srH_V-py3.9/lib/python3.9/site-packages/asyauth/protocols/ntlm/creds_calc.py", line 523, in NTOWFv1
    return hashlib.md4(password.encode('utf-16le')).digest()
AttributeError: 'NoneType' object has no attribute 'encode'
```

because the `password` attribute is `None`, which is logic.

However if I'm using this URL connection `rdp+ntlm-password://:@IP`, both `username` and `password` are equal to '' (empty), I receive a `0xc000006d` code which I think means **the username or password is incorrect.**

## Wanted behaviour:
Using this URL connection `rdp+ntlm-password://IP` I want to authenticate as anonymous, like the previous version of `aardwolf`. 

Sorry in advance if it's a mistake from my side.

Regards.