### PR TITLE
Amputate 1st byte of CredSSP signature check on version < 5

### DIFF
--- a/asyauth/protocols/credssp/client/native.py
+++ b/asyauth/protocols/credssp/client/native.py
@@ -258,7 +258,7 @@ class CredSSPClientNative:
 						if verification_data != ClientServerHash:
 							raise Exception('CredSSP - Server verification failed!')
 					elif self.version in [2,3,4]:
-						if verification_data != self.__pubkey:
+						if verification_data[1:] != self.__pubkey[1:]:
 							raise Exception('CredSSP - Server verification failed!')
 					
 					# Signatures verified, now we can send the final auth token with the password


### PR DESCRIPTION
Regarding #5 
The server signature check is only partially valid on lower CredSSP versions. I haven't managed to find a case where the 1st byte actually match the client public key.
Is the `SPNEGOClientNative.decrypt()` function responsible ?
If you have additional info or any idea about why that happens :)
Thanks :smiley: 
