### PR TITLE
Fix crossrealm krb auth with ticket

### DIFF
--- a/asyauth/protocols/kerberos/client/native.py
+++ b/asyauth/protocols/kerberos/client/native.py
@@ -139,7 +139,9 @@ class KerberosClientNative:
 					for target in self.ccred.ccache.list_targets():
 						# just printing this to debug...
 						logger.debug('CCACHE SPN record: %s' % target)
-					tgs, encpart, self.session_key = await self.kc.get_TGS(spn)
+					tgs, encpart, self.session_key, err = self.kc.tgs_from_ccache(spn)
+					if err:
+						raise err
 					logger.debug('Got TGS from CCACHE!')
 					
 					self.from_ccache = True


### PR DESCRIPTION
Before this PR asyauth supported cross realm only with `kerberos+password` but not with krb TGT ticket such as `kerberos+ccache` or `kerberos+kirbi`. Indeed, if a TGT was provided, `def authenticate` from `native.py` was calling `get_TGS` l.142 which was trying to retrieve a ST from the TGT without taking into account a cross realm case so was ending up with a referral ticket and tried to use it as a ST for the cross realm service instead of performing another ST request with the referral to have the right cross realm ST ticket.\
Here an example using msldap, there is a bidirectionnal trust between `bloody.corp` and `outsider.lab` and the `bloody.corp` user `john` wants to login on `outsider.lab`:
```
$ klist john.ccache                                                                                                                                                         
Ticket cache: FILE:john.ccache
Default principal: john@BLOODY.CORP

Valid starting       Expires              Service principal
11/29/2024 03:56:20  11/29/2024 13:56:20  krbtgt/BLOODY.CORP@BLOODY.CORP
                                                                                                                                                                                              
$ msldap -v 'ldap+kerberos-ccache://bloody.corp\john:john.ccache@dc1.outsider.lab/?serverip=192.168.100.10&dc=192.168.100.3&dcc=192.168.100.10&realmc=outsider.lab' 'login' 

2024-11-29 05:24:50,342 msldap       DEBUG    ==== UniCredential ====
domain: bloody.corp
username: john
secret: john.ccache
stype: CCACHE
protocol: KERBEROS
subprotocol: <asyauth.common.subprotocols.native.SubProtocolNative object at 0x7ff73819fd50>
etypes: [23, 17, 18]
altname: None
altdomain: None
target: ==== UniTarget ====
hostname: None
port: 88
protocol: UniProto.CLIENT_TCP
timeout: 5
ssl_ctx: None
dc_ip: 192.168.100.3
domain: None
dns: None
use_privileged_source_port: False
proxies: []
ip: 192.168.100.3

certdata: None
keydata: None
cross_target: ==== UniTarget ====
hostname: None
port: 88
protocol: UniProto.CLIENT_TCP
timeout: 5
ssl_ctx: None
dc_ip: 192.168.100.10
domain: None
dns: None
use_privileged_source_port: False
proxies: []
ip: 192.168.100.10

cross_realm: outsider.lab
dh_params: {'p': 179769313486231590770839156793787453197860296048756011706444423684197180216158519368947833795864925541502180565485980503646440548199239100050792877003355816639229553136239076508735759914822574862575007425302077447712589550957937778424442426617334727629299387668709205606050270810842907692932019128194467627007, 'g': 2}

DEBUG:msldap:==== UniCredential ====
domain: bloody.corp
username: john
secret: john.ccache
stype: CCACHE
protocol: KERBEROS
subprotocol: <asyauth.common.subprotocols.native.SubProtocolNative object at 0x7ff73819fd50>
etypes: [23, 17, 18]
altname: None
altdomain: None
target: ==== UniTarget ====
hostname: None
port: 88
protocol: UniProto.CLIENT_TCP
timeout: 5
ssl_ctx: None
dc_ip: 192.168.100.3
domain: None
dns: None
use_privileged_source_port: False
proxies: []
ip: 192.168.100.3

certdata: None
keydata: None
cross_target: ==== UniTarget ====
hostname: None
port: 88
protocol: UniProto.CLIENT_TCP
timeout: 5
ssl_ctx: None
dc_ip: 192.168.100.10
domain: None
dns: None
use_privileged_source_port: False
proxies: []
ip: 192.168.100.10

cross_realm: outsider.lab
dh_params: {'p': 179769313486231590770839156793787453197860296048756011706444423684197180216158519368947833795864925541502180565485980503646440548199239100050792877003355816639229553136239076508735759914822574862575007425302077447712589550957937778424442426617334727629299387668709205606050270810842907692932019128194467627007, 'g': 2}

2024-11-29 05:24:50,342 msldap       DEBUG    ==== MSLDAPTarget ====
hostname: dc1.outsider.lab
port: 389
protocol: UniProto.CLIENT_TCP
timeout: 5
ssl_ctx: None
dc_ip: 192.168.100.3
domain: bloody.corp
dns: None
use_privileged_source_port: False
proxies: []
ip: 192.168.100.10
tree: None
ldap_query_page_size: 1000
ldap_query_ratelimit: 0

DEBUG:msldap:==== MSLDAPTarget ====
hostname: dc1.outsider.lab
port: 389
protocol: UniProto.CLIENT_TCP
timeout: 5
ssl_ctx: None
dc_ip: 192.168.100.3
domain: bloody.corp
dns: None
use_privileged_source_port: False
proxies: []
ip: 192.168.100.10
tree: None
ldap_query_page_size: 1000
ldap_query_ratelimit: 0

2024-11-29 05:24:50,355 msldap       DEBUG    Connecting!
DEBUG:msldap:Connecting!
2024-11-29 05:24:50,356 msldap       DEBUG    Connection succsessful!
DEBUG:msldap:Connection succsessful!
2024-11-29 05:24:50,356 msldap       DEBUG    BIND in progress...
DEBUG:msldap:BIND in progress...
2024-11-29 05:24:50,357 asyauth.kerberos DEBUG    Flags: 48
2024-11-29 05:24:50,357 asyauth.kerberos DEBUG    SPN: ldap/dc1.outsider.lab@bloody.corp
2024-11-29 05:24:50,357 asyauth.kerberos DEBUG    CCACHE SPN record: krbtgt/BLOODY.CORP@BLOODY.CORP
2024-11-29 05:24:50,367 asyauth.kerberos DEBUG    Got TGS from CCACHE!
2024-11-29 05:24:50,367 asyauth.kerberos DEBUG    TGS: OrderedDict([('pvno', 5), ('msg-type', 13), ('padata', None), ('crealm', 'BLOODY.CORP'), ('cname', OrderedDict([('name-type', 1), ('name-string', ['john'])])), ('ticket', OrderedDict([('tkt-vno', 5), ('realm', 'BLOODY.CORP'), ('sname', OrderedDict([('name-type', 2), ('name-string', ['krbtgt', 'OUTSIDER.LAB'])])), ('enc-part', OrderedDict([('etype', 23), ('kvno', None), ('cipher', b'\x18H\xfbo\x11\xd6>\xeb\xb5\xde\x13,_\xc9\xc6\x06\x9a*\x98\x8c\xc1o\xf4A\xe9\xfc4\xa7\xd3\xfd\x93\xdcz\x9f\x92DCk\x8c\xb1\r\xef\x9f[&\x1d\xbd\x82CZ\x01\xbdk\xd7,L=P\xf0\x89]\x80B8^Ll\xc7\x88m\x9b\xfd\xa89\xfeon\xb6"\xeft\xf7\xa2\xd9\x05\x94\xa3n8/4l\xf1H\x11\xf8\x97F\xfbvY\xc4\x00_\x19u\xbag\xda\xb1\xf2,\xaaGd\xa4\x8e\xb9\x95\xc4\xe88A\x0f\xf5\x81\x89\xac\xb2\xaa\xc0K\xa2X\x1e\x9f\xc4\xfe\nIG\xe9\xc6\x01d\xf7\xe1\x19d]\xf6\x8fbH\xf2\x85\x88\x8c\xcf\t\xa7$\x97\xbf\x04\xa2\xddD\xa7\xd5\xd47\x99\xf4\xc9Xu\xd9\xbf$\xd8\x89k[>?\x83\x838SE\x13_\r\xc3\xc8\\\x9c\x9b\\\xdfd\xfb\xc8Q|L\xbb\x9fyt\xb0<R]}\xee\xc3\xf3\xcaD\rM\xf4\xf9_\xf4\x13\xbd\xe5E\xa9\xda\x8b\x8c\xb4\xb2\x81\x02\xcf:\x8e\xcbJ\xabX\xcei\xad\xac\xbf\xc5+\x8b\x80\xe72}\xb1\x1bX\x06T\x83\xe7_\ts\x04\xc9Q\x9bW(\x16\xbc\xb1\xd2\xf5\x8f\xb5\xb6D6\xe2\x15\xa4\xd7`\xe9\x1cV\xc9\x17\xcd\x07wYV\x87\xd3\xc3\x8c|h\x9eG\x83\xe8,\x8c\x06\x82\xff\'\x0b\xde\x10\x83\xd8%R\x97\xfc\x05/\x0f\xf4\x8b\xff\x1b#\x93\xe3\xda\xb6\xd2\xeb,\x9a\xd8\tA\xd2hU\xa8W\xbd\x1d\x8a\xbf}?\x8a}\x14\xb7osx\xc6T6\xc7\xf2\xfc\x19\xee\xeb\xc1@%S\xcc\xf9\xb1\xcf~\xc4\t\xe9\xa1\xefIH\x07O/\xf4\xbb\x96\x16Db\\\xaa\xa5\xefI\x18R\x91\xad\xec\x1a\x97\x01\xd1<\xc2\xeb\xc5#\x13\xc3\xd4\xa3\x06\xb8\x0e\x8f|\x914\xed:\x89\xb0a\x90E\x98z\x89\xb17\x00\xd2l\xe2\x95\x07\x15\xf5C\x8cg\x04\xdf\xc4\x7fJ\xaf\xff\x03\xbdx\x15\xc8\xc9\x14A\x02\x90E\xb6\xdb\x16\xb7\xec$\x98G`\x18\xa0#\xaa[\xf1_%\x0e\x18Eov\xab\xde/\xa1\xd7\xdfeeYM\xd2\\w\x85\xeb\xb7\xe0\x8d\xd7L\'\xdbZ\xfe*:\x8c\xf6k\xc1\x17\xaeYjk\xaeLae\xf8\xbd\x98z\x88\xc1\xf4\xa8\x9d\xc2\xc9\r\x9e\x98<\x99\xac\x97\x95\xf9\xff^\xb5\x7f\xe5\x97*\xa9[\xb1\xc4\xf4\xd3\xb0x\x97\xf1\xbf\xe4O\'-\xfd\xc9i\xccr\x94SE\x01\xdd\xe5\x10`\xad}\xb0^\xbf:\xc8\xd1\x85\xdd\x88\x99\xfd\xa4\x08j\xc0A\xb9\xb0\xe0\xf3_&\xad\xc0\xb7\xb4\xd6\x03\xb9\x13\xca\n\xfb\x94\xeb\x0e\xca\x9a=v\xd1\x84\xa1\x0f:L\xa1F\x01\xbf\x93\xc8\xd2U\x7f\x0cX>\xa0U\x96\xaa\xeaaXy->\x8c\xa9!\xbc\xef\xa8\x13T\xad\x99\x91\xec\x9e\xa5\xe3w\xa9\xacs\xd8,\x93\xf5\x80Q.y\x84\xcb\xb3\xcd\xa3^E\xbd\x97gu\xf4\xaa\xd1\xbe\xcb\xdb\xa4\xc1\xe7\'\xb1\xec\x87\x02\xb3\x9bx\xb1!\xbd\x0b\xad\xbel\xe8\x15\xc71BuVR\x9cC\x91>\xb8\x15\xe1\xd2\x8cOE\xd7\x88\xb3\xf3\x7f+\xa4>\xbfIZ\x13L\xcdsl{\xd2s\r\xa3g _\xbaW\xb0{\xef\x19\x95D\xb5k\xbe\xabMMy|\xf3K3-\xd6l\xb5\x0e\x17\xedA!\xca\x1d\xa3Z\xa7\xf2\x08\xea\xa3\xc8\xe4V\xd1a\xd8K\x1a\x80\xf5$i\xb5\x00>\x00Rmn\x90\xa1R\x0f\x08q%Y\xe2I\x1bz\xeb<\x86\x06(\xa9K\xa1?\xe2\xc8\xc6SW\xdc\x9a\x8b\xad\x10\x91t\xd1vg\x1bw8\x8a\xb8\x84 \xefG\xce\x96|\x132S\xb3\xe05mL\xe8\x88nn\x04\xcd\xfa\xbbn\xa9\x8cu\xa3\xf8<\xad\xd5\xfbK\xfcC\xcf\x1c\xde\xbd\xae\xc8\xbc\x99E\x16x\xdc\x1a\xb5\x1e\xe3JA\xe6\xf4k? \xa26 \xae\\\x90\x9c\x1as\x02c-!\xff\xf49\xad\x9b\xd3M\x1c\xf2\xb2\xbd\xd6  \x07\xbb\xbaI-\xd3\xbc\x89\xd4\xb4*\xd6\xfa"\xcb\x15q*\x16\xden\xd9s\x8f\x90a\xb2\xe0\x04$B\xfd\x85\xdb\xcd\xa2\x1e\xb7\x1f\x14w\xf0\x9c\xc8#\xe3\x89)\x1c\x85\xbco\xd6\xd8\xab\xb6\xcc\x04:\xacZ\x18\xfe"\xe8\x8a\x95=\xa2\xdc\x92\xa25\xef\x91\xffZ\xec\xc2r\xb8 \x9f};\x90\x89\xc2+I\x8c\xe3')]))])), ('enc-part', OrderedDict([('etype', 23), ('kvno', None), ('cipher', b'\xfd=\xc8g\xd5\x1a\x04\xe8H\x8e\xfe\xba\x82\xd6w\xde\xfc\xefVk\xe0\x89\xefC\xbc\xe1\x97B\x96\xdacE\xa9v\xe1\x0e\xc2\xb2H\xbfJ>\xac\xc0K3\x96;\xe0\xf7\xc2\x96B\x97Z\xae\x04=\xee\xae/\xdeM1\x80/\x97\xa1\x9a\xee2\xb2H\xf3j\x8c\x9c|WG[\x16P\xbaU4L\xe8\x1c\xc06\x80Y\xdc#\x941iu\x1elz\xc6\x13\xea\xd3\x04\x89.\xb3o\x1e\x84\x899\x8e\xe7\xe1\x06it(\x16\xf3\x80\xedt\xc46~sN\tP\rp\xb9M$\xa22kE\x11mt\x08rS\x11\xef1cuB\xd6\x9ah\x86|\\\x80\x8c\x1c\xad\x98\x87v:t!\x1a#O\xb7`?\xc6\xc5qCP\xfa\x80\x8f7O\xca7\xd7\xdc\xf1#3\xdep\xa0L\x89\xf7|;\xab\xdf\xb0\xe1\xd0\xdb\xf4\xb3\x9anxs\xe1+\x93\xc4\xf0\x91~\xf8\x88\xa8f\x16\xfe\x92\xbb\xe2\x88d\xf9E\'`\xc9g\xbbY\xdc\xc2\xb9\xb8-\xfe^\xb6\x10\xba\xb8\x1c\x81\xab\xb4!a\x18\xd7\xab\xb8\x8f\x13f\x9f\xca\x87\xc4\xb9\xdc\x994\x08O?\xbf\x0b\xcb\x85"\x9c')]))])
2024-11-29 05:24:50,367 asyauth.kerberos DEBUG    encpart: OrderedDict([('key', OrderedDict([('keytype', 23), ('keyvalue', b'\x85\xe0GZ3\xed\xf5\t\xdb\x18W4\x9e\xc0 {')])), ('last-req', [OrderedDict([('lr-type', 0), ('lr-value', datetime.datetime(2024, 11, 29, 4, 24, 51, tzinfo=datetime.timezone.utc))])]), ('nonce', 2010238084), ('key-expiration', None), ('flags', {'forwardable', 'pre-authent', 'renewable', 'enc-pa-rep'}), ('authtime', datetime.datetime(2024, 11, 29, 2, 56, 20, tzinfo=datetime.timezone.utc)), ('starttime', datetime.datetime(2024, 11, 29, 4, 24, 51, tzinfo=datetime.timezone.utc)), ('endtime', datetime.datetime(2024, 11, 29, 12, 56, 20, tzinfo=datetime.timezone.utc)), ('renew-till', datetime.datetime(2024, 11, 30, 2, 56, 20, tzinfo=datetime.timezone.utc)), ('srealm', 'BLOODY.CORP'), ('sname', OrderedDict([('name-type', 2), ('name-string', ['krbtgt', 'OUTSIDER.LAB'])])), ('caddr', None), ('encrypted-pa-data', [OrderedDict([('padata-type', 20), ('padata-value', b'0\x10\xa0\x0e\x1b\x0cOUTSIDER.LAB')]), OrderedDict([('padata-type', 165), ('padata-value', b'\x07\x00\x00\x00')])])])
2024-11-29 05:24:50,367 asyauth.kerberos DEBUG    session_key: Key(23, 85e0475a33edf509db1857349ec0207b)
2024-11-29 05:24:50,368 asyauth.kerberos DEBUG    APREQ constructed: b'n\x82\x05\r0\x82\x05\t\xa0\x03\x02\x01\x05\xa1\x03\x02\x01\x0e\xa2\x03\x03\x01\x00\xa3\x82\x04\\a\x82\x04X0\x82\x04T\xa0\x03\x02\x01\x05\xa1\r\x1b\x0bBLOODY.CORP\xa2!0\x1f\xa0\x03\x02\x01\x02\xa1\x180\x16\x1b\x06krbtgt\x1b\x0cOUTSIDER.LAB\xa3\x82\x04\x190\x82\x04\x15\xa0\x03\x02\x01\x17\xa2\x82\x04\x0c\x04\x82\x04\x08\x18H\xfbo\x11\xd6>\xeb\xb5\xde\x13,_\xc9\xc6\x06\x9a*\x98\x8c\xc1o\xf4A\xe9\xfc4\xa7\xd3\xfd\x93\xdcz\x9f\x92DCk\x8c\xb1\r\xef\x9f[&\x1d\xbd\x82CZ\x01\xbdk\xd7,L=P\xf0\x89]\x80B8^Ll\xc7\x88m\x9b\xfd\xa89\xfeon\xb6"\xeft\xf7\xa2\xd9\x05\x94\xa3n8/4l\xf1H\x11\xf8\x97F\xfbvY\xc4\x00_\x19u\xbag\xda\xb1\xf2,\xaaGd\xa4\x8e\xb9\x95\xc4\xe88A\x0f\xf5\x81\x89\xac\xb2\xaa\xc0K\xa2X\x1e\x9f\xc4\xfe\nIG\xe9\xc6\x01d\xf7\xe1\x19d]\xf6\x8fbH\xf2\x85\x88\x8c\xcf\t\xa7$\x97\xbf\x04\xa2\xddD\xa7\xd5\xd47\x99\xf4\xc9Xu\xd9\xbf$\xd8\x89k[>?\x83\x838SE\x13_\r\xc3\xc8\\\x9c\x9b\\\xdfd\xfb\xc8Q|L\xbb\x9fyt\xb0<R]}\xee\xc3\xf3\xcaD\rM\xf4\xf9_\xf4\x13\xbd\xe5E\xa9\xda\x8b\x8c\xb4\xb2\x81\x02\xcf:\x8e\xcbJ\xabX\xcei\xad\xac\xbf\xc5+\x8b\x80\xe72}\xb1\x1bX\x06T\x83\xe7_\ts\x04\xc9Q\x9bW(\x16\xbc\xb1\xd2\xf5\x8f\xb5\xb6D6\xe2\x15\xa4\xd7`\xe9\x1cV\xc9\x17\xcd\x07wYV\x87\xd3\xc3\x8c|h\x9eG\x83\xe8,\x8c\x06\x82\xff\'\x0b\xde\x10\x83\xd8%R\x97\xfc\x05/\x0f\xf4\x8b\xff\x1b#\x93\xe3\xda\xb6\xd2\xeb,\x9a\xd8\tA\xd2hU\xa8W\xbd\x1d\x8a\xbf}?\x8a}\x14\xb7osx\xc6T6\xc7\xf2\xfc\x19\xee\xeb\xc1@%S\xcc\xf9\xb1\xcf~\xc4\t\xe9\xa1\xefIH\x07O/\xf4\xbb\x96\x16Db\\\xaa\xa5\xefI\x18R\x91\xad\xec\x1a\x97\x01\xd1<\xc2\xeb\xc5#\x13\xc3\xd4\xa3\x06\xb8\x0e\x8f|\x914\xed:\x89\xb0a\x90E\x98z\x89\xb17\x00\xd2l\xe2\x95\x07\x15\xf5C\x8cg\x04\xdf\xc4\x7fJ\xaf\xff\x03\xbdx\x15\xc8\xc9\x14A\x02\x90E\xb6\xdb\x16\xb7\xec$\x98G`\x18\xa0#\xaa[\xf1_%\x0e\x18Eov\xab\xde/\xa1\xd7\xdfeeYM\xd2\\w\x85\xeb\xb7\xe0\x8d\xd7L\'\xdbZ\xfe*:\x8c\xf6k\xc1\x17\xaeYjk\xaeLae\xf8\xbd\x98z\x88\xc1\xf4\xa8\x9d\xc2\xc9\r\x9e\x98<\x99\xac\x97\x95\xf9\xff^\xb5\x7f\xe5\x97*\xa9[\xb1\xc4\xf4\xd3\xb0x\x97\xf1\xbf\xe4O\'-\xfd\xc9i\xccr\x94SE\x01\xdd\xe5\x10`\xad}\xb0^\xbf:\xc8\xd1\x85\xdd\x88\x99\xfd\xa4\x08j\xc0A\xb9\xb0\xe0\xf3_&\xad\xc0\xb7\xb4\xd6\x03\xb9\x13\xca\n\xfb\x94\xeb\x0e\xca\x9a=v\xd1\x84\xa1\x0f:L\xa1F\x01\xbf\x93\xc8\xd2U\x7f\x0cX>\xa0U\x96\xaa\xeaaXy->\x8c\xa9!\xbc\xef\xa8\x13T\xad\x99\x91\xec\x9e\xa5\xe3w\xa9\xacs\xd8,\x93\xf5\x80Q.y\x84\xcb\xb3\xcd\xa3^E\xbd\x97gu\xf4\xaa\xd1\xbe\xcb\xdb\xa4\xc1\xe7\'\xb1\xec\x87\x02\xb3\x9bx\xb1!\xbd\x0b\xad\xbel\xe8\x15\xc71BuVR\x9cC\x91>\xb8\x15\xe1\xd2\x8cOE\xd7\x88\xb3\xf3\x7f+\xa4>\xbfIZ\x13L\xcdsl{\xd2s\r\xa3g _\xbaW\xb0{\xef\x19\x95D\xb5k\xbe\xabMMy|\xf3K3-\xd6l\xb5\x0e\x17\xedA!\xca\x1d\xa3Z\xa7\xf2\x08\xea\xa3\xc8\xe4V\xd1a\xd8K\x1a\x80\xf5$i\xb5\x00>\x00Rmn\x90\xa1R\x0f\x08q%Y\xe2I\x1bz\xeb<\x86\x06(\xa9K\xa1?\xe2\xc8\xc6SW\xdc\x9a\x8b\xad\x10\x91t\xd1vg\x1bw8\x8a\xb8\x84 \xefG\xce\x96|\x132S\xb3\xe05mL\xe8\x88nn\x04\xcd\xfa\xbbn\xa9\x8cu\xa3\xf8<\xad\xd5\xfbK\xfcC\xcf\x1c\xde\xbd\xae\xc8\xbc\x99E\x16x\xdc\x1a\xb5\x1e\xe3JA\xe6\xf4k? \xa26 \xae\\\x90\x9c\x1as\x02c-!\xff\xf49\xad\x9b\xd3M\x1c\xf2\xb2\xbd\xd6  \x07\xbb\xbaI-\xd3\xbc\x89\xd4\xb4*\xd6\xfa"\xcb\x15q*\x16\xden\xd9s\x8f\x90a\xb2\xe0\x04$B\xfd\x85\xdb\xcd\xa2\x1e\xb7\x1f\x14w\xf0\x9c\xc8#\xe3\x89)\x1c\x85\xbco\xd6\xd8\xab\xb6\xcc\x04:\xacZ\x18\xfe"\xe8\x8a\x95=\xa2\xdc\x92\xa25\xef\x91\xffZ\xec\xc2r\xb8 \x9f};\x90\x89\xc2+I\x8c\xe3\xa4\x81\x970\x81\x94\xa0\x03\x02\x01\x17\xa2\x81\x8c\x04\x81\x89\x07\xe8\x1c,\xa7c\xc20\x07Q\x04.\xcapi\x1b\xb64B\x99\x15\x9d\xda\x1aZ\xd1!T\x90\xf8\xcc\\Y8\x99\x8d\x12\xf9\xee/\xe8`\x1c\xc48\xc0b\xe5\x93\xb9\x1a5\xbc\x17\xccZ[t\x03\x91 U\x0bL\xabJ\xe8;J\xcc\xfc\xe3K\xd3\x06\xc3\x93\xdb]\xd3\xad\xb3M\xdd\n5;\xb6 \xcb\xe9\x89\xe2\xe1\xe5\xf2\x1b\xf7\xb9>G! \xb2\r\x1b\x83 \xbeZ\xe1\x8d\x01Ks\xa2tk\xb4\xd91\xbc\xbaU\xec+\xf8\x980u_-\xc4\x1b\xf4\x9d\xb1'
Traceback (most recent call last):
  File "/home/silver/.local/lib/python3.11/site-packages/msldap/examples/msldapclient.py", line 90, in do_login
    raise err
msldap.commons.exceptions.LDAPBindException: LDAP Bind failed! Result code: "invalidCredentials" Reason: "b'8009030C: LdapErr: DSID-0C090585, comment: AcceptSecurityContext error, data 52e, v4f7c\x00'"
```
And now an example using `kerberos+password` which works because the `list_targets` l.139 raise an error and we enter into the `except:` l.148 which fetch a tgt first then a referral ticket because it's cross realm then a ST:
```
$ msldap -v 'ldap+kerberos-password://bloody.corp\john:Password123!@dc1.outsider.lab/?serverip=192.168.100.10&dc=192.168.100.3&dcc=192.168.100.10&realmc=outsider.lab' 'login'
2024-11-29 05:28:26,813 msldap       DEBUG    ==== UniCredential ====
domain: bloody.corp
username: john
secret: Password123!
stype: PASSWORD
protocol: KERBEROS
subprotocol: <asyauth.common.subprotocols.native.SubProtocolNative object at 0x7fcf37d1be90>
etypes: [23, 17, 18]
altname: None
altdomain: None
target: ==== UniTarget ====
hostname: None
port: 88
protocol: UniProto.CLIENT_TCP
timeout: 5
ssl_ctx: None
dc_ip: 192.168.100.3
domain: None
dns: None
use_privileged_source_port: False
proxies: []
ip: 192.168.100.3

certdata: None
keydata: None
cross_target: ==== UniTarget ====
hostname: None
port: 88
protocol: UniProto.CLIENT_TCP
timeout: 5
ssl_ctx: None
dc_ip: 192.168.100.10
domain: None
dns: None
use_privileged_source_port: False
proxies: []
ip: 192.168.100.10

cross_realm: outsider.lab
dh_params: {'p': 179769313486231590770839156793787453197860296048756011706444423684197180216158519368947833795864925541502180565485980503646440548199239100050792877003355816639229553136239076508735759914822574862575007425302077447712589550957937778424442426617334727629299387668709205606050270810842907692932019128194467627007, 'g': 2}

DEBUG:msldap:==== UniCredential ====
domain: bloody.corp
username: john
secret: Password123!
stype: PASSWORD
protocol: KERBEROS
subprotocol: <asyauth.common.subprotocols.native.SubProtocolNative object at 0x7fcf37d1be90>
etypes: [23, 17, 18]
altname: None
altdomain: None
target: ==== UniTarget ====
hostname: None
port: 88
protocol: UniProto.CLIENT_TCP
timeout: 5
ssl_ctx: None
dc_ip: 192.168.100.3
domain: None
dns: None
use_privileged_source_port: False
proxies: []
ip: 192.168.100.3

certdata: None
keydata: None
cross_target: ==== UniTarget ====
hostname: None
port: 88
protocol: UniProto.CLIENT_TCP
timeout: 5
ssl_ctx: None
dc_ip: 192.168.100.10
domain: None
dns: None
use_privileged_source_port: False
proxies: []
ip: 192.168.100.10

cross_realm: outsider.lab
dh_params: {'p': 179769313486231590770839156793787453197860296048756011706444423684197180216158519368947833795864925541502180565485980503646440548199239100050792877003355816639229553136239076508735759914822574862575007425302077447712589550957937778424442426617334727629299387668709205606050270810842907692932019128194467627007, 'g': 2}

2024-11-29 05:28:26,813 msldap       DEBUG    ==== MSLDAPTarget ====
hostname: dc1.outsider.lab
port: 389
protocol: UniProto.CLIENT_TCP
timeout: 5
ssl_ctx: None
dc_ip: 192.168.100.3
domain: bloody.corp
dns: None
use_privileged_source_port: False
proxies: []
ip: 192.168.100.10
tree: None
ldap_query_page_size: 1000
ldap_query_ratelimit: 0

DEBUG:msldap:==== MSLDAPTarget ====
hostname: dc1.outsider.lab
port: 389
protocol: UniProto.CLIENT_TCP
timeout: 5
ssl_ctx: None
dc_ip: 192.168.100.3
domain: bloody.corp
dns: None
use_privileged_source_port: False
proxies: []
ip: 192.168.100.10
tree: None
ldap_query_page_size: 1000
ldap_query_ratelimit: 0

2024-11-29 05:28:26,819 msldap       DEBUG    Connecting!
DEBUG:msldap:Connecting!
2024-11-29 05:28:26,820 msldap       DEBUG    Connection succsessful!
DEBUG:msldap:Connection succsessful!
2024-11-29 05:28:26,820 msldap       DEBUG    BIND in progress...
DEBUG:msldap:BIND in progress...
2024-11-29 05:28:26,821 asyauth.kerberos DEBUG    Flags: 48
2024-11-29 05:28:26,821 asyauth.kerberos DEBUG    SPN: ldap/dc1.outsider.lab@bloody.corp
2024-11-29 05:28:26,865 asyauth.kerberos DEBUG    TGS: OrderedDict([('pvno', 5), ('msg-type', 13), ('padata', None), ('crealm', 'BLOODY.CORP'), ('cname', OrderedDict([('name-type', 1), ('name-string', ['john'])])), ('ticket', OrderedDict([('tkt-vno', 5), ('realm', 'OUTSIDER.LAB'), ('sname', OrderedDict([('name-type', 2), ('name-string', ['ldap', 'dc1.outsider.lab'])])), ('enc-part', OrderedDict([('etype', 18), ('kvno', 3), ('cipher', b'\x13\x9b\xd2A\x11\xeb*\x15l\xa0.U\xb9\xc5e\x10Q\x15\x86\x18U\x14I\xf1\x83\x87\xce\x9c\xed\x81B\xef\x9f\xaa\n\xbe\xeb\xda\xb0]9\xc6Q\x16\xbb\x04\x1c\xcc\x9f\xc5\x13F\x8c:q \xb3@\xb2\xa6\x8fB\xd1\x96o\xdd#\x91A\x92\x07\xd69;p\xbb6W\xb4\xb4\xaa\x8e\xa9M\x84\x9e\x01-z\t*v\xaf\xdbX?\x99\xa4\x90\xcf\xee\xbd]T\xe9\x93\x13%\x92\rG5\xd9\xd1\x93\xc8\xa0?~Y\xd3)Au\xb4\xc0\xa5\xf0\x1f\x97\x17\xb0g>\xd21\xf9T\x02\xe9\xf2]\xd0\xea\x83\x9f\xee<\x96\xa1\x92-\xf2y\xc2\xd2\xca]\xc2-![2\xea2\xf8\x9d\xa1^k\x9f\x05-\xc9\x8e\x8f}\x04>aTE\r\x86\xa9\xb6\xb9\xdd\xcf\xbe` \x0c({\x15"\xc4b\x98a\x97S\xd6\xde\x84\x14\x1fe\xce\xa4\x0e\xc4\xf1\x9ff\xa4\xa4-\xe3\xf0,\x10.\xe2\xa6\x1fG\x06\x88\x8f\xfd\x87)[$13\x89\xf0p\xea/\xb9N\xbf\xeba\xa4T\x7f\x0f^\x0c{\xe8\xe3\xd4n\xaego\x8fIe\x1awN\x94\xc8\x04R\x86&\xbc\x86\x18"\x86_\x99L\xed]\xeb\xf6\xda\t\xc9=(\x1e0E\xb1\xe4\xc7\xd2\xde\x92\xf9\x9bCz\x93m?\xdb\x18\xa9\xcc%\xb0\x08\xb7\x84\xc5\xa4\x03\xa1\x94\xe2\xca/J\xfc\xfc\xf4\x8fGy\xd2\x0c\x19\xcb\x9e#I: \xbc\xb3R\xcb\x17\xb5X\xcb"\xce\x83\x84L\x95\xb4`\x93\xd3O/\xcb\x91\xf0%+e\xee\x88\xeeKN\xfa\x02k!Y\xdd\x9eJ4\n\xe5\xabR\xfctb\x86\xda\xeb}\xa3\xb1\x7f"\x98\xedXC\x93\xe7\xbb\n\x9d\xb5\x13+\x8fMt\xb4J%\x13\xd2\xb2i\xbd,@\x1c\xc98r\x03\xf7\xe8\xdc\xe0i\xf6\xcf\xf5{\x83>\xdfp\xd5\xed\x04=0\x08a\x9a\xc7\x89s\x89\xdd8\xd4t\xe3>\x05 \x95Z\x9bn\xf8\xea\xaf\xd0aA\x9d\x98+\xb9\x01\xfcR?vl\x17\x9a}\x00GU\xe4\xd1\xaa\xc8*\xd9\x7f7\x9fU\xc8\x97\x0b\x17\x07\xe7\x9f2\x14\xcdx"q\x07\x18+i\xb1\xab\xe0\xecJUyHw\xc4,.\xf1\xcb\x8ew\xcf\x11\xef\xd4\x8f\xc9\x17\xff\xf2\xc5\x827r\x85Q\x0b\x12o\xab\xde]\x89\x94\xa0\x06\xb1\xfe\x85\xe4\x1a\x07\x8a\xc2\x0coSf\xc2t\x1d\x19H&1\xae\x7f\xe3\x9f\xd8@_\xc9Z\xda\xa1F\xd2\xe5eDpJQ\xa6\xac\x89Q\x91\xe0N\x9c\xb3\xec\x8f=\xea\xc6^\x02\x17\xdd\xc2\xe6SW\xd9\xc4y\xfeEpL\x80`E\x8f\x04\xbf!\xdaA\xf4\'\x9c;\xce=\x1fH\xa7\xb7\x9eI&\xcbA\xb6.\x80\xa1\x82c\x93t]\x8f\xe6\xd1a6\xebuO\xe2D\xa0\r\xeeqm\x0c\xf6}:z\xc4Qj\xfd\x84\x01\xaf\x81\xa6\xdd5\xd7\xa6\x94\xe2\x08\x81T\x05\xc3\x9d\xcfJ\xd2%\xfc\xaf\xfc\xda\x01s\xe3\x1c\'\x0f\x99\xc4\xd8\xee&\xf5F\x17\xdb\xb2\xec@\x84\xa9n?\xf3\x80\xdd7<\x90\xfea\xea\xe1Z\xd9-L\x16U.R\x81\xb1\x92\x1c\xb6e\xdbO\x15\x99\x13U<\xfb\x1cIs\xe4\xff\x18\xc7\xb4c\xb4D2k\nf:\xce\x04\xd5\xe8\xe4\xcf\x93x\x14\xd1\xfc1Z/\xbc\xb6\x9f\x03j\x93\x9b\xa9\xb7i\x17G\xca\xd3\x9d\xf3%m\x08\xc2lc\x1a\xa1]\xdb\xac\xdev~\xc2k\t%4M\xe0\x03\xaccG\xcd\xbc\x11PP\xb7\xa3\x8b\xba\xc6id\xd7\xc9?\x82\xf9-\xc6\x89\x86m=\xce\xf9\xf3s\xff\xfe\xe5\xdd&\x97\x8cZ]`q\xf9V1\x18_5\x9b\xba"\xfb\xb0\xdarz\x08\n_,D\x1a\x88\x10\xea\xcd\xbf\x9cxb\x95\xa7C(\xe0\xa4\xbe\'\x17\x11\xc1[+\x9b\xbf\xd8\xd5\xf3\x0c\xc5\x17t\xa5\x18\xd4\xc5t\x948\x8d\xb1Q\xd6T<\xa1\x0e\x1cY\x86meW\x9a\xa9\xbd\x10\xe5\xcdh\x0f\n\xc7\xbf\x0e"\xaa\x04?\xd18C\xfd\xa1\xde+{(\xb9\'T\x01\xa8\xda/\xf8\x88\xa8\xb6~\x8fI\x03S\x9c\xdeW\x18')]))])), ('enc-part', OrderedDict([('etype', 23), ('kvno', None), ('cipher', b'\xa5\x99\x92\xdce\\\xee\nD5\x0e\xf31 tos\x82\xa8\x8d\xb6\xe1\\.\x10\xd6\xd3+\x91&\x1a\xea\xa7(\x83\xc0\x8e\xfe\x9c\xbaH\x9by\xf0\xc8\x1f\x83\xac\x8a\xb6\x8a\xc6\to\x9er\xa3* Tq\xe8\x8f\x89Y8\xb0\x0fnhR\x0bd\xdc|\x94\xd8\xd9\xff\x1e>o\x8a\xd2\x1eJ\xbc\xa4l\xc4A#c\xd9g/\xdd\x0cS\xbe\xcce\xa3\nt\xadhjA\xbc\xbc1*\xa3\xb0\xf9\x1e\x88\xab\x8e\x18u\xdc\x1b\x08\xb0\x05\xa0v\xc2\xca\x07\x94G#z\xce|\xce\xd8w\n\xa7\xdao\xbd:v{\x91%\xd9\x7f\xbc\xba\x8c:\xc9wJ\xa4\xa9\x0btI\xbf\xeb\xa7\xd3\x00\x86_2\xb0\xf0r\xe8d\x03\xadh/\x1dg\xfb\xd0\xd6\xb2\xc0\xdb\x15\xb7\xb1\xd3\xa83\x85\x86G\x8a\xe6\x02\xb1\xb2\xd5\xd9\xc0g\xcbhl1\xb1\x15]\x950\x88\xa0\xec\xb7s\x08\xc6\x8b\x1d\xf0\x80\xb8Ab\xa0)]\xbaX\xe2#-\xaf\x006S\x8b\r7{V\xed\x89\x7f<m\xc2\xcc')]))])
2024-11-29 05:28:26,867 asyauth.kerberos DEBUG    encpart: OrderedDict([('key', OrderedDict([('keytype', 23), ('keyvalue', b'\xf2\xf2\x1a\xdc\xef\x00\x19\x99v\xe3\xad\xb8\x9a\xae\x15\xb8')])), ('last-req', [OrderedDict([('lr-type', 0), ('lr-value', datetime.datetime(2024, 11, 29, 4, 28, 28, tzinfo=datetime.timezone.utc))])]), ('nonce', 92930937), ('key-expiration', None), ('flags', {'pre-authent', 'renewable', 'ok-as-delegate', 'enc-pa-rep', 'forwardable'}), ('authtime', datetime.datetime(2024, 11, 29, 4, 28, 28, tzinfo=datetime.timezone.utc)), ('starttime', datetime.datetime(2024, 11, 29, 4, 28, 28, tzinfo=datetime.timezone.utc)), ('endtime', datetime.datetime(2024, 11, 29, 14, 28, 28, tzinfo=datetime.timezone.utc)), ('renew-till', datetime.datetime(2024, 11, 30, 4, 28, 26, tzinfo=datetime.timezone.utc)), ('srealm', 'OUTSIDER.LAB'), ('sname', OrderedDict([('name-type', 2), ('name-string', ['ldap', 'dc1.outsider.lab'])])), ('caddr', None), ('encrypted-pa-data', [OrderedDict([('padata-type', 165), ('padata-value', b'\x1f\x00\x00\x00')])])])
2024-11-29 05:28:26,867 asyauth.kerberos DEBUG    session_key: Key(23, f2f21adcef00199976e3adb89aae15b8)
2024-11-29 05:28:26,868 asyauth.kerberos DEBUG    APREQ constructed: b'n\x82\x04\xe10\x82\x04\xdd\xa0\x03\x02\x01\x05\xa1\x03\x02\x01\x0e\xa2\x03\x03\x01\x00\xa3\x82\x040a\x82\x04,0\x82\x04(\xa0\x03\x02\x01\x05\xa1\x0e\x1b\x0cOUTSIDER.LAB\xa2#0!\xa0\x03\x02\x01\x02\xa1\x1a0\x18\x1b\x04ldap\x1b\x10dc1.outsider.lab\xa3\x82\x03\xea0\x82\x03\xe6\xa0\x03\x02\x01\x12\xa1\x03\x02\x01\x03\xa2\x82\x03\xd8\x04\x82\x03\xd4\x13\x9b\xd2A\x11\xeb*\x15l\xa0.U\xb9\xc5e\x10Q\x15\x86\x18U\x14I\xf1\x83\x87\xce\x9c\xed\x81B\xef\x9f\xaa\n\xbe\xeb\xda\xb0]9\xc6Q\x16\xbb\x04\x1c\xcc\x9f\xc5\x13F\x8c:q \xb3@\xb2\xa6\x8fB\xd1\x96o\xdd#\x91A\x92\x07\xd69;p\xbb6W\xb4\xb4\xaa\x8e\xa9M\x84\x9e\x01-z\t*v\xaf\xdbX?\x99\xa4\x90\xcf\xee\xbd]T\xe9\x93\x13%\x92\rG5\xd9\xd1\x93\xc8\xa0?~Y\xd3)Au\xb4\xc0\xa5\xf0\x1f\x97\x17\xb0g>\xd21\xf9T\x02\xe9\xf2]\xd0\xea\x83\x9f\xee<\x96\xa1\x92-\xf2y\xc2\xd2\xca]\xc2-![2\xea2\xf8\x9d\xa1^k\x9f\x05-\xc9\x8e\x8f}\x04>aTE\r\x86\xa9\xb6\xb9\xdd\xcf\xbe` \x0c({\x15"\xc4b\x98a\x97S\xd6\xde\x84\x14\x1fe\xce\xa4\x0e\xc4\xf1\x9ff\xa4\xa4-\xe3\xf0,\x10.\xe2\xa6\x1fG\x06\x88\x8f\xfd\x87)[$13\x89\xf0p\xea/\xb9N\xbf\xeba\xa4T\x7f\x0f^\x0c{\xe8\xe3\xd4n\xaego\x8fIe\x1awN\x94\xc8\x04R\x86&\xbc\x86\x18"\x86_\x99L\xed]\xeb\xf6\xda\t\xc9=(\x1e0E\xb1\xe4\xc7\xd2\xde\x92\xf9\x9bCz\x93m?\xdb\x18\xa9\xcc%\xb0\x08\xb7\x84\xc5\xa4\x03\xa1\x94\xe2\xca/J\xfc\xfc\xf4\x8fGy\xd2\x0c\x19\xcb\x9e#I: \xbc\xb3R\xcb\x17\xb5X\xcb"\xce\x83\x84L\x95\xb4`\x93\xd3O/\xcb\x91\xf0%+e\xee\x88\xeeKN\xfa\x02k!Y\xdd\x9eJ4\n\xe5\xabR\xfctb\x86\xda\xeb}\xa3\xb1\x7f"\x98\xedXC\x93\xe7\xbb\n\x9d\xb5\x13+\x8fMt\xb4J%\x13\xd2\xb2i\xbd,@\x1c\xc98r\x03\xf7\xe8\xdc\xe0i\xf6\xcf\xf5{\x83>\xdfp\xd5\xed\x04=0\x08a\x9a\xc7\x89s\x89\xdd8\xd4t\xe3>\x05 \x95Z\x9bn\xf8\xea\xaf\xd0aA\x9d\x98+\xb9\x01\xfcR?vl\x17\x9a}\x00GU\xe4\xd1\xaa\xc8*\xd9\x7f7\x9fU\xc8\x97\x0b\x17\x07\xe7\x9f2\x14\xcdx"q\x07\x18+i\xb1\xab\xe0\xecJUyHw\xc4,.\xf1\xcb\x8ew\xcf\x11\xef\xd4\x8f\xc9\x17\xff\xf2\xc5\x827r\x85Q\x0b\x12o\xab\xde]\x89\x94\xa0\x06\xb1\xfe\x85\xe4\x1a\x07\x8a\xc2\x0coSf\xc2t\x1d\x19H&1\xae\x7f\xe3\x9f\xd8@_\xc9Z\xda\xa1F\xd2\xe5eDpJQ\xa6\xac\x89Q\x91\xe0N\x9c\xb3\xec\x8f=\xea\xc6^\x02\x17\xdd\xc2\xe6SW\xd9\xc4y\xfeEpL\x80`E\x8f\x04\xbf!\xdaA\xf4\'\x9c;\xce=\x1fH\xa7\xb7\x9eI&\xcbA\xb6.\x80\xa1\x82c\x93t]\x8f\xe6\xd1a6\xebuO\xe2D\xa0\r\xeeqm\x0c\xf6}:z\xc4Qj\xfd\x84\x01\xaf\x81\xa6\xdd5\xd7\xa6\x94\xe2\x08\x81T\x05\xc3\x9d\xcfJ\xd2%\xfc\xaf\xfc\xda\x01s\xe3\x1c\'\x0f\x99\xc4\xd8\xee&\xf5F\x17\xdb\xb2\xec@\x84\xa9n?\xf3\x80\xdd7<\x90\xfea\xea\xe1Z\xd9-L\x16U.R\x81\xb1\x92\x1c\xb6e\xdbO\x15\x99\x13U<\xfb\x1cIs\xe4\xff\x18\xc7\xb4c\xb4D2k\nf:\xce\x04\xd5\xe8\xe4\xcf\x93x\x14\xd1\xfc1Z/\xbc\xb6\x9f\x03j\x93\x9b\xa9\xb7i\x17G\xca\xd3\x9d\xf3%m\x08\xc2lc\x1a\xa1]\xdb\xac\xdev~\xc2k\t%4M\xe0\x03\xaccG\xcd\xbc\x11PP\xb7\xa3\x8b\xba\xc6id\xd7\xc9?\x82\xf9-\xc6\x89\x86m=\xce\xf9\xf3s\xff\xfe\xe5\xdd&\x97\x8cZ]`q\xf9V1\x18_5\x9b\xba"\xfb\xb0\xdarz\x08\n_,D\x1a\x88\x10\xea\xcd\xbf\x9cxb\x95\xa7C(\xe0\xa4\xbe\'\x17\x11\xc1[+\x9b\xbf\xd8\xd5\xf3\x0c\xc5\x17t\xa5\x18\xd4\xc5t\x948\x8d\xb1Q\xd6T<\xa1\x0e\x1cY\x86meW\x9a\xa9\xbd\x10\xe5\xcdh\x0f\n\xc7\xbf\x0e"\xaa\x04?\xd18C\xfd\xa1\xde+{(\xb9\'T\x01\xa8\xda/\xf8\x88\xa8\xb6~\x8fI\x03S\x9c\xdeW\x18\xa4\x81\x970\x81\x94\xa0\x03\x02\x01\x17\xa2\x81\x8c\x04\x81\x89\x1d\x05}d\xc0\x18\xb4\x91\xa4\x97\xbc\x89p\x9b\xf8V\xb7\xfb\xcd\x8c8l\x83S\xac/Q?\x11\x87!\x0b\xe2\x93\x85\t\x16\r\x02h\xb9\xeeA{q.N|\x9b\xfe\xa1\xe8[6\xdf\x81\xc7|ER\x1b\xd8\x01|ov\xf8wM\x99"\x83\x9a\xa4F,is\xa9\xf6\x83\x95\x87\x8f5\x88Ku\x8a\x07\xe8\x8bW\x13[ZT\xe5y44\r\xe6\x87 \xd4\x80\xee\x10\x9cz\x95\xa7\xb3\xebqz\xd3\xc6\x99E_\xb8\xb2z\x87\xb5\xe49CV\xf0@\xc0\xcc\xae\x02'
2024-11-29 05:28:26,873 msldap       DEBUG    BIND Success!
DEBUG:msldap:BIND Success!
2024-11-29 05:28:26,877 msldap       DEBUG    Polling AD for basic info
DEBUG:msldap:Polling AD for basic info
2024-11-29 05:28:26,877 msldap       DEBUG    Paged search, filter: (distinguishedName=DC=outsider,DC=lab) attributes: auditingPolicy,creationTime,dc,distinguishedName,forceLogoff,instanceType,lockoutDuration,lockOutObservationWindow,lockoutThreshold,masteredBy,maxPwdAge,minPwdAge,minPwdLength,name,nextRid,nTSecurityDescriptor,objectCategory,objectClass,objectGUID,objectSid,pwdHistoryLength,pwdProperties,serverState,systemFlags,uASCompat,uSNChanged,uSNCreated,whenChanged,whenCreated,rIDManagerReference,msDS-Behavior-Version,description,isDeleted,gPLink,ms-DS-MachineAccountQuota
DEBUG:msldap:Paged search, filter: (distinguishedName=DC=outsider,DC=lab) attributes: auditingPolicy,creationTime,dc,distinguishedName,forceLogoff,instanceType,lockoutDuration,lockOutObservationWindow,lockoutThreshold,masteredBy,maxPwdAge,minPwdAge,minPwdLength,name,nextRid,nTSecurityDescriptor,objectCategory,objectClass,objectGUID,objectSid,pwdHistoryLength,pwdProperties,serverState,systemFlags,uASCompat,uSNChanged,uSNCreated,whenChanged,whenCreated,rIDManagerReference,msDS-Behavior-Version,description,isDeleted,gPLink,ms-DS-MachineAccountQuota
2024-11-29 05:28:26,885 msldap       DEBUG    BIND OK!
DEBUG:msldap:BIND OK!
2024-11-29 05:28:26,885 msldap       DEBUG    Tree, dn: DC=outsider,DC=lab level: 1
```
And now with the fix if there is not already a ST from cache matching the service we target with our user it will also go to the `except:` part and handle correctly cross domain:
```
$ msldap -v 'ldap+kerberos-ccache://bloody.corp\john:john.ccache@dc1.outsider.lab/?serverip=192.168.100.10&dc=192.168.100.3&dcc=192.168.100.10&realmc=outsider.lab' 'login'
2024-11-29 05:33:24,163 msldap       DEBUG    ==== UniCredential ====
domain: bloody.corp
username: john
secret: john.ccache
stype: CCACHE
protocol: KERBEROS
subprotocol: <asyauth.common.subprotocols.native.SubProtocolNative object at 0x7f0c67dc3d10>
etypes: [23, 17, 18]
altname: None
altdomain: None
target: ==== UniTarget ====
hostname: None
port: 88
protocol: UniProto.CLIENT_TCP
timeout: 5
ssl_ctx: None
dc_ip: 192.168.100.3
domain: None
dns: None
use_privileged_source_port: False
proxies: []
ip: 192.168.100.3

certdata: None
keydata: None
cross_target: ==== UniTarget ====
hostname: None
port: 88
protocol: UniProto.CLIENT_TCP
timeout: 5
ssl_ctx: None
dc_ip: 192.168.100.10
domain: None
dns: None
use_privileged_source_port: False
proxies: []
ip: 192.168.100.10

cross_realm: outsider.lab
dh_params: {'p': 179769313486231590770839156793787453197860296048756011706444423684197180216158519368947833795864925541502180565485980503646440548199239100050792877003355816639229553136239076508735759914822574862575007425302077447712589550957937778424442426617334727629299387668709205606050270810842907692932019128194467627007, 'g': 2}

DEBUG:msldap:==== UniCredential ====
domain: bloody.corp
username: john
secret: john.ccache
stype: CCACHE
protocol: KERBEROS
subprotocol: <asyauth.common.subprotocols.native.SubProtocolNative object at 0x7f0c67dc3d10>
etypes: [23, 17, 18]
altname: None
altdomain: None
target: ==== UniTarget ====
hostname: None
port: 88
protocol: UniProto.CLIENT_TCP
timeout: 5
ssl_ctx: None
dc_ip: 192.168.100.3
domain: None
dns: None
use_privileged_source_port: False
proxies: []
ip: 192.168.100.3

certdata: None
keydata: None
cross_target: ==== UniTarget ====
hostname: None
port: 88
protocol: UniProto.CLIENT_TCP
timeout: 5
ssl_ctx: None
dc_ip: 192.168.100.10
domain: None
dns: None
use_privileged_source_port: False
proxies: []
ip: 192.168.100.10

cross_realm: outsider.lab
dh_params: {'p': 179769313486231590770839156793787453197860296048756011706444423684197180216158519368947833795864925541502180565485980503646440548199239100050792877003355816639229553136239076508735759914822574862575007425302077447712589550957937778424442426617334727629299387668709205606050270810842907692932019128194467627007, 'g': 2}

2024-11-29 05:33:24,164 msldap       DEBUG    ==== MSLDAPTarget ====
hostname: dc1.outsider.lab
port: 389
protocol: UniProto.CLIENT_TCP
timeout: 5
ssl_ctx: None
dc_ip: 192.168.100.3
domain: bloody.corp
dns: None
use_privileged_source_port: False
proxies: []
ip: 192.168.100.10
tree: None
ldap_query_page_size: 1000
ldap_query_ratelimit: 0

DEBUG:msldap:==== MSLDAPTarget ====
hostname: dc1.outsider.lab
port: 389
protocol: UniProto.CLIENT_TCP
timeout: 5
ssl_ctx: None
dc_ip: 192.168.100.3
domain: bloody.corp
dns: None
use_privileged_source_port: False
proxies: []
ip: 192.168.100.10
tree: None
ldap_query_page_size: 1000
ldap_query_ratelimit: 0

2024-11-29 05:33:24,172 msldap       DEBUG    Connecting!
DEBUG:msldap:Connecting!
2024-11-29 05:33:24,175 msldap       DEBUG    Connection succsessful!
DEBUG:msldap:Connection succsessful!
2024-11-29 05:33:24,175 msldap       DEBUG    BIND in progress...
DEBUG:msldap:BIND in progress...
2024-11-29 05:33:24,176 asyauth.kerberos DEBUG    Flags: 48
2024-11-29 05:33:24,176 asyauth.kerberos DEBUG    SPN: ldap/dc1.outsider.lab@bloody.corp
2024-11-29 05:33:24,176 asyauth.kerberos DEBUG    CCACHE SPN record: krbtgt/BLOODY.CORP@BLOODY.CORP
2024-11-29 05:33:24,242 asyauth.kerberos DEBUG    TGS: OrderedDict([('pvno', 5), ('msg-type', 13), ('padata', None), ('crealm', 'BLOODY.CORP'), ('cname', OrderedDict([('name-type', 1), ('name-string', ['john'])])), ('ticket', OrderedDict([('tkt-vno', 5), ('realm', 'OUTSIDER.LAB'), ('sname', OrderedDict([('name-type', 2), ('name-string', ['ldap', 'dc1.outsider.lab'])])), ('enc-part', OrderedDict([('etype', 18), ('kvno', 3), ('cipher', b'\x99U\xea\x9b\x9e\xf1\x02\xc2Fw<\x14\xdbG\x1fgZ\x0e\xd5bj\x18\xc18\xcaA0\x16\xdf~\xc0o\xb9&\xd0\xe3\xb8\nj\xff\x06=\x16\x128\x8e\x12g\x97X\x81\xe9\x0f\x84*\xd1\xa2\xa8\x96\xe8P\x9b\x07\x11F\xac\x8f\x85\x88\xff\x89\xfc\x11~bK\xf4\x16r\xcb\xfa\xe4{\xd1\x0c\xc3\xb4\xa1\xce\x8b8\xe5\xf7\nv\xf0c}\x89\x8d`\xae\x99\x00\x86\xbe\xaaX\x87\x06\xa6%\x00\n\xcb:x\xef\x15I\x03\xb9\x05\xca\x8e\xa2\xccx\xa6\x82\x1a\xd4g\x96L\xb1\xc93\xe5\xac\x1d\x8e\xf4M\xcb\x06\x96Q\xf2%\xec\x0e\x05\x1e0\xcc\x8b\x1b\x89\x95\xf1\xe2\xa8\x0f\xf9\x0bQ\xe9\x8eI\x98\xe3)\xe1\x98i\xcf\xe1\xc2\xdcq=\x064\xf0\n\x07e\x8e\xb7?9\xcb\xaf\xf8;g%\xe4\x88,\xc7S\xe6\x87`\x80\x0f\xdc\xa11c\xecI\x875I\xa1\x8c`\x0e\x14\xf6\x01o`\xe5Y6\x8d%\x8c0\xd4\x153\x1avc)j\x8d\x87\xf2\x1eW-\xd1jh\x05\x91Tc\x83\xfbn\xb0\xdd\x89\xectL\x13!c\xc5\xc3\xf7\xdc\x10s\xfe\xce\x8d\x1b\xa6;\x15\x10\xfcU8\xa8\xf8\x83X\xc9\x87\xb0\xe1\xd8\xc3g\xfd\xa3\x97s\xa0\xaf\xc8\x19\x8dE\xa2\x1e*\xf5\xf0\x94\xd2,N\x897\xc1\xff \xfe\x81(\x9f\x88\xed\xa5\x1cJ\xa8\xc5\x8eP\x06Q\'\xfc\x15j\xd8ZpFg\xddo=\x97K\xb2\xa86\xc7NrZ\xf8\x0f\x05<\xe5\xef8\'\x98\xa8\xd1\x14[@\xa1\xbe\xfa\xac\x90\x91\xf98,\x94\xd5\xe8X\x18\x0e;\xe4\xccqg\xf7\x89\xb3\xa5\x03O\x1b\xb9\xb4\x8b\r\x96\xbcB\x16\x04z\xd9yf\x10\xe6oZpO\x822\xc2\xaf4\\\x03?\x10* \xb1\xb5G5\xc3M\xb4#\xc6p\xd9\x98\xf7\x10p\xec\xcd\xfa\xb4\x13O\x1f\xfd}\xe8(>\xf9_\xf4?R\xe4\'\xe2A\xbbh\x15\xa4x.\xd6\n\xc3\xbcc\xdaF\xdeFC*}X\xf0\x03t/\x04{\xc8!\xbc\xa3\xca\x02t\xa2\xf9\xee\x91i\x81\xab\x85\x9f3m\x86\x87\xad\xc6\xfd\xb1Z\xefyROM{v\xe64h\x08"2\x9f\x94Y\xe1C\xfb\xde\x9a"\xd3\x07\xbd\xa16u\x9c\x857F\x10\x88;\x02\xb4\x8d*\xe0\x9eR\xe30\xc3\xe3 \xaf\xb9\x92\xb2|Zq$\xbd\x1a\x10$\xea\x00\x11\xba\x85k\xfe\xd7+\xe5\x82\x80\xf8\xcb\x00\xd9\xed\x9e\x02\xce\xd8\xba\\\xeb\xa3\xe3=vR\xa3\xc728`\x03\xfc\x7f^^\xbdx%\xea\x90c\x8ay\xa9z\xe0%\xaei\xf7\xc3\xd0\x93\xe0\x05f\xf1^\x12\x1a\xb0\xd9\x95]-\'\xd23\xd6X\tU\xbf\xd3\xda\xbd\xb3\x92\xf02\xd3\x1a\x93\xe3\x99\xa4\x11N\xa8;\x8d\x1cVh\x17\xa2\xc46\x9f\xfa\x14\xb3~\xd5 \xec\xb2\xdcQ\xe6\x01\xed\xca\x98\xa0\xb2\xe6m\xbd!_\xda\xa0\xdb\xfb\xed\xb0i\xddN\x89\xab\xc8\xc89\xae%S\xd0+\'\x853\x0733\x96\x8e\x99\x86\xcd\xac\x1c\x0b\xe2Y\xbb\xa6\xc1f\xdc\x89 M7\xbe\t\x85\xce\xaf\x9e\xc4\xb3\xaa\xbb\t\x82\xa4,~h\x05\x95\xc6\x9eO}z\x1b\xe3\xdc\xc2%~\xe1rdY\x10\x17\xd2S\x04\xcc0\x07\x87&BT\xe5a\xff\x15\xcaj\xe5\xddS\x9a\xfeG<\x16\x1d"\x84n\x9e\x04\xe4\x8a\x8d\xf2\xb6\x14\xd4H\nb\xe7\x8aX\xdff\xdf2\xb7\xfc\xfa\xfc\xb8\xcd\x05\x08\xb8E}1+\xf7\xf09)\xafjX\\{\xdd\x08+hZ\x07\xf1\x07\xa4\xa1\xf2\xf0\xed\xb7{b\xedG\xb7yJX~\xafb\xeaN\xb4\xf3\x9a\x95\xb4\xc4|\x933\xb6!.\x03\xcc\x0bX^4\x94\xcd/\xf30\xde\xbb\x88\x16f\xf3\x06v \x11\x82!\x8fI>\xaf\x93X\xd1\xeb?\x90W\xc6b)]\x93X\xb65\xd2/SH\xc2\xf2ov!\x04\xb9\x99\x9e^9\t\x19\xec\xa2\xc4\xf4Z\t\x13<\x0bmF\xd0\xee`\x11\xa4\x9b\xdeBNL\xfc>P\xb1\x1e\x04\x94X\x84\xb6\xe4\xfeK\xd63E\xc7\xcf')]))])), ('enc-part', OrderedDict([('etype', 23), ('kvno', None), ('cipher', b'\x9c\xe0\x88A\xe9c\x82\xe0\xa2\xae/\x01b\x1e]\xcaxp\x08\x83L\x8b.\xa6\xed\x02\xb1\xa2\xea\xff\xf9-\x86\xeaT}\x17+\xfaVf\x0f&dg\xff\x8b&\xbe\xf8\xa3\xb6%\x83$\xf88W\x9a\xfd\x924\x11\x01\xf2\xc4P\xc4\x96\x83\xdch\xdf\x0f%:8\xad\xd7G\xdc&\n\xfe\x9c\x19\xf2\x83\xf5?\x8dSc\xcd\xae\xacIZ\xe5\xea{#O\x1c\x8d\xd9b\x08\xea\x95#\x0c\x99\xaa\xcf\xbf\xa2\xfa>\xf4\xdb\x81R\x9eEKC\xa7\x1a\xefKD\xaczmI\x12B\xa0\xbchsW\xe6\xc8(^\xde\x06\xf4\r\x12\xb6\xd6\x0fd\xe7\x06\xbfC\xcd\x8c\xde\xa1\xf2\xba\x08\xce\xfd\xef\xf3/~\xcb\xd4\x85\x98-\x91\xe5\x11g\x7f\x05\x00\x8c\xeba?fYv\x80\xd1\x90\xee\xfdA\x87\xad\xd5\x93r\x14YjT\xef\xca<\xfa\x00\xe3l>\x87$\x14\xe6\x05l)\xc7\xf2\x9c\xbd\xa20\xab\xe9\x90A\xc6\x96mms\xa7\x0b\x8e\xc7\xc6\xc41\xefS\xa0G\xb3\x13\x89*\xd5\x06\x94')]))])
2024-11-29 05:33:24,242 asyauth.kerberos DEBUG    encpart: OrderedDict([('key', OrderedDict([('keytype', 23), ('keyvalue', b'_\xf6\x1a\xa1\xcaQ\xf7\xdb(\x1dQ\xe8\x95\x1fH\xdc')])), ('last-req', [OrderedDict([('lr-type', 0), ('lr-value', datetime.datetime(2024, 11, 29, 4, 33, 25, tzinfo=datetime.timezone.utc))])]), ('nonce', 2075325343), ('key-expiration', None), ('flags', {'pre-authent', 'renewable', 'forwardable', 'enc-pa-rep', 'ok-as-delegate'}), ('authtime', datetime.datetime(2024, 11, 29, 2, 56, 20, tzinfo=datetime.timezone.utc)), ('starttime', datetime.datetime(2024, 11, 29, 4, 33, 25, tzinfo=datetime.timezone.utc)), ('endtime', datetime.datetime(2024, 11, 29, 12, 56, 20, tzinfo=datetime.timezone.utc)), ('renew-till', datetime.datetime(2024, 11, 30, 2, 56, 20, tzinfo=datetime.timezone.utc)), ('srealm', 'OUTSIDER.LAB'), ('sname', OrderedDict([('name-type', 2), ('name-string', ['ldap', 'dc1.outsider.lab'])])), ('caddr', None), ('encrypted-pa-data', [OrderedDict([('padata-type', 165), ('padata-value', b'\x1f\x00\x00\x00')])])])
2024-11-29 05:33:24,242 asyauth.kerberos DEBUG    session_key: Key(23, 5ff61aa1ca51f7db281d51e8951f48dc)
2024-11-29 05:33:24,242 asyauth.kerberos DEBUG    APREQ constructed: b'n\x82\x04\xe10\x82\x04\xdd\xa0\x03\x02\x01\x05\xa1\x03\x02\x01\x0e\xa2\x03\x03\x01\x00\xa3\x82\x040a\x82\x04,0\x82\x04(\xa0\x03\x02\x01\x05\xa1\x0e\x1b\x0cOUTSIDER.LAB\xa2#0!\xa0\x03\x02\x01\x02\xa1\x1a0\x18\x1b\x04ldap\x1b\x10dc1.outsider.lab\xa3\x82\x03\xea0\x82\x03\xe6\xa0\x03\x02\x01\x12\xa1\x03\x02\x01\x03\xa2\x82\x03\xd8\x04\x82\x03\xd4\x99U\xea\x9b\x9e\xf1\x02\xc2Fw<\x14\xdbG\x1fgZ\x0e\xd5bj\x18\xc18\xcaA0\x16\xdf~\xc0o\xb9&\xd0\xe3\xb8\nj\xff\x06=\x16\x128\x8e\x12g\x97X\x81\xe9\x0f\x84*\xd1\xa2\xa8\x96\xe8P\x9b\x07\x11F\xac\x8f\x85\x88\xff\x89\xfc\x11~bK\xf4\x16r\xcb\xfa\xe4{\xd1\x0c\xc3\xb4\xa1\xce\x8b8\xe5\xf7\nv\xf0c}\x89\x8d`\xae\x99\x00\x86\xbe\xaaX\x87\x06\xa6%\x00\n\xcb:x\xef\x15I\x03\xb9\x05\xca\x8e\xa2\xccx\xa6\x82\x1a\xd4g\x96L\xb1\xc93\xe5\xac\x1d\x8e\xf4M\xcb\x06\x96Q\xf2%\xec\x0e\x05\x1e0\xcc\x8b\x1b\x89\x95\xf1\xe2\xa8\x0f\xf9\x0bQ\xe9\x8eI\x98\xe3)\xe1\x98i\xcf\xe1\xc2\xdcq=\x064\xf0\n\x07e\x8e\xb7?9\xcb\xaf\xf8;g%\xe4\x88,\xc7S\xe6\x87`\x80\x0f\xdc\xa11c\xecI\x875I\xa1\x8c`\x0e\x14\xf6\x01o`\xe5Y6\x8d%\x8c0\xd4\x153\x1avc)j\x8d\x87\xf2\x1eW-\xd1jh\x05\x91Tc\x83\xfbn\xb0\xdd\x89\xectL\x13!c\xc5\xc3\xf7\xdc\x10s\xfe\xce\x8d\x1b\xa6;\x15\x10\xfcU8\xa8\xf8\x83X\xc9\x87\xb0\xe1\xd8\xc3g\xfd\xa3\x97s\xa0\xaf\xc8\x19\x8dE\xa2\x1e*\xf5\xf0\x94\xd2,N\x897\xc1\xff \xfe\x81(\x9f\x88\xed\xa5\x1cJ\xa8\xc5\x8eP\x06Q\'\xfc\x15j\xd8ZpFg\xddo=\x97K\xb2\xa86\xc7NrZ\xf8\x0f\x05<\xe5\xef8\'\x98\xa8\xd1\x14[@\xa1\xbe\xfa\xac\x90\x91\xf98,\x94\xd5\xe8X\x18\x0e;\xe4\xccqg\xf7\x89\xb3\xa5\x03O\x1b\xb9\xb4\x8b\r\x96\xbcB\x16\x04z\xd9yf\x10\xe6oZpO\x822\xc2\xaf4\\\x03?\x10* \xb1\xb5G5\xc3M\xb4#\xc6p\xd9\x98\xf7\x10p\xec\xcd\xfa\xb4\x13O\x1f\xfd}\xe8(>\xf9_\xf4?R\xe4\'\xe2A\xbbh\x15\xa4x.\xd6\n\xc3\xbcc\xdaF\xdeFC*}X\xf0\x03t/\x04{\xc8!\xbc\xa3\xca\x02t\xa2\xf9\xee\x91i\x81\xab\x85\x9f3m\x86\x87\xad\xc6\xfd\xb1Z\xefyROM{v\xe64h\x08"2\x9f\x94Y\xe1C\xfb\xde\x9a"\xd3\x07\xbd\xa16u\x9c\x857F\x10\x88;\x02\xb4\x8d*\xe0\x9eR\xe30\xc3\xe3 \xaf\xb9\x92\xb2|Zq$\xbd\x1a\x10$\xea\x00\x11\xba\x85k\xfe\xd7+\xe5\x82\x80\xf8\xcb\x00\xd9\xed\x9e\x02\xce\xd8\xba\\\xeb\xa3\xe3=vR\xa3\xc728`\x03\xfc\x7f^^\xbdx%\xea\x90c\x8ay\xa9z\xe0%\xaei\xf7\xc3\xd0\x93\xe0\x05f\xf1^\x12\x1a\xb0\xd9\x95]-\'\xd23\xd6X\tU\xbf\xd3\xda\xbd\xb3\x92\xf02\xd3\x1a\x93\xe3\x99\xa4\x11N\xa8;\x8d\x1cVh\x17\xa2\xc46\x9f\xfa\x14\xb3~\xd5 \xec\xb2\xdcQ\xe6\x01\xed\xca\x98\xa0\xb2\xe6m\xbd!_\xda\xa0\xdb\xfb\xed\xb0i\xddN\x89\xab\xc8\xc89\xae%S\xd0+\'\x853\x0733\x96\x8e\x99\x86\xcd\xac\x1c\x0b\xe2Y\xbb\xa6\xc1f\xdc\x89 M7\xbe\t\x85\xce\xaf\x9e\xc4\xb3\xaa\xbb\t\x82\xa4,~h\x05\x95\xc6\x9eO}z\x1b\xe3\xdc\xc2%~\xe1rdY\x10\x17\xd2S\x04\xcc0\x07\x87&BT\xe5a\xff\x15\xcaj\xe5\xddS\x9a\xfeG<\x16\x1d"\x84n\x9e\x04\xe4\x8a\x8d\xf2\xb6\x14\xd4H\nb\xe7\x8aX\xdff\xdf2\xb7\xfc\xfa\xfc\xb8\xcd\x05\x08\xb8E}1+\xf7\xf09)\xafjX\\{\xdd\x08+hZ\x07\xf1\x07\xa4\xa1\xf2\xf0\xed\xb7{b\xedG\xb7yJX~\xafb\xeaN\xb4\xf3\x9a\x95\xb4\xc4|\x933\xb6!.\x03\xcc\x0bX^4\x94\xcd/\xf30\xde\xbb\x88\x16f\xf3\x06v \x11\x82!\x8fI>\xaf\x93X\xd1\xeb?\x90W\xc6b)]\x93X\xb65\xd2/SH\xc2\xf2ov!\x04\xb9\x99\x9e^9\t\x19\xec\xa2\xc4\xf4Z\t\x13<\x0bmF\xd0\xee`\x11\xa4\x9b\xdeBNL\xfc>P\xb1\x1e\x04\x94X\x84\xb6\xe4\xfeK\xd63E\xc7\xcf\xa4\x81\x970\x81\x94\xa0\x03\x02\x01\x17\xa2\x81\x8c\x04\x81\x89\xf4\xf2.\xac\xd5\xd0\xd2JN\xba\x7f\xa3\xa0\xc6\xbb\xe2\xa8\xa5\xa1\xfa\xa7\xdc\x03\x953\xe2x\xa5C\x8f\xd7\xa5\xba\x95\xb1\x9c\xa9Z\x13b\xad\x01\xa4\x1d\xb8_\x80\xe0\xec\xce\xd6\x80\x14\xe7\x90\xb9k\xcf\xcb\x9d.\x7fq\xe8\xf6\x84{{\xbfw\x06\x14\xb2\xfbw\\v\x90\x9d\x02\x8c\x11\x96D\x8ftm\xd5\x18UG\xc8\xf3F\xa1sW9\xc3\xd7\xa2\x93\x1e\xd88by\xf5\xa0r\'1\x93\xc8\x99\xe2\xe3\x90\x0e\xc2l\xba\xfan/\xb8\xdb\xdde\x19\xa0T\xbed\x04B}'
2024-11-29 05:33:24,246 msldap       DEBUG    BIND Success!
DEBUG:msldap:BIND Success!
2024-11-29 05:33:24,248 msldap       DEBUG    Polling AD for basic info
DEBUG:msldap:Polling AD for basic info
2024-11-29 05:33:24,248 msldap       DEBUG    Paged search, filter: (distinguishedName=DC=outsider,DC=lab) attributes: auditingPolicy,creationTime,dc,distinguishedName,forceLogoff,instanceType,lockoutDuration,lockOutObservationWindow,lockoutThreshold,masteredBy,maxPwdAge,minPwdAge,minPwdLength,name,nextRid,nTSecurityDescriptor,objectCategory,objectClass,objectGUID,objectSid,pwdHistoryLength,pwdProperties,serverState,systemFlags,uASCompat,uSNChanged,uSNCreated,whenChanged,whenCreated,rIDManagerReference,msDS-Behavior-Version,description,isDeleted,gPLink,ms-DS-MachineAccountQuota
DEBUG:msldap:Paged search, filter: (distinguishedName=DC=outsider,DC=lab) attributes: auditingPolicy,creationTime,dc,distinguishedName,forceLogoff,instanceType,lockoutDuration,lockOutObservationWindow,lockoutThreshold,masteredBy,maxPwdAge,minPwdAge,minPwdLength,name,nextRid,nTSecurityDescriptor,objectCategory,objectClass,objectGUID,objectSid,pwdHistoryLength,pwdProperties,serverState,systemFlags,uASCompat,uSNChanged,uSNCreated,whenChanged,whenCreated,rIDManagerReference,msDS-Behavior-Version,description,isDeleted,gPLink,ms-DS-MachineAccountQuota
2024-11-29 05:33:24,253 msldap       DEBUG    BIND OK!
DEBUG:msldap:BIND OK!
2024-11-29 05:33:24,254 msldap       DEBUG    Tree, dn: DC=outsider,DC=lab level: 1
```