### PR TITLE
Improve pkinit part

### DIFF
--- a/asyauth/common/credentials/__init__.py
+++ b/asyauth/common/credentials/__init__.py
@@ -197,7 +197,7 @@ class UniCredential:
 			if extra['dcc'] is not None:
 				cross_target = UniTarget(extra['dcc'], 88, UniProto.CLIENT_TCP, proxies = proxies, dns=params['dnsc'], dc_ip=extra['dcc'])
 
-			etypes = extra['etype'] if extra['etype'] is not None else [23,17,18]
+			etypes = extra['etype']
 
 			return credobj(
 				secret, 

--- a/asyauth/common/credentials/kerberos.py
+++ b/asyauth/common/credentials/kerberos.py
@@ -11,7 +11,7 @@ from asyauth.utils.paramprocessor import str_one, int_one, bool_one, int_list
 #from minikerberos.pkinit import PKINIT
 
 class KerberosCredential(UniCredential):
-	def __init__(self, secret, username, domain, stype:asyauthSecret, target:UniTarget = None, altname:str = None, altdomain:str = None, etypes:List[int] = [23,17,18], subprotocol:SubProtocol = SubProtocolNative(), certdata:str = None, keydata:str=None, cross_target:UniTarget = None, cross_realm:str = None):
+	def __init__(self, secret, username, domain, stype:asyauthSecret, target:UniTarget = None, altname:str = None, altdomain:str = None, etypes:List[int] = None, subprotocol:SubProtocol = SubProtocolNative(), certdata:str = None, keydata:str=None, cross_target:UniTarget = None, cross_realm:str = None):
 		UniCredential.__init__(
 			self, 
 			secret = secret,
@@ -41,7 +41,7 @@ class KerberosCredential(UniCredential):
 		self.sanity_check()
 	
 	def sanity_check(self):
-		if self.domain is None or self.domain == '':
+		if self.stype not in [asyauthSecret.PFX, asyauthSecret.PFXSTR, asyauthSecret.PFXB64, asyauthSecret.PFXHEX, asyauthSecret.PEM] and not self.domain:
 			raise Exception('Kerberos credential must have domain set! %s' % str(self))
 		if self.target is None or self.target.dc_ip is None:
 			raise Exception('Kerberos credential target must have dc_ip set!')		
@@ -90,9 +90,9 @@ class KerberosCredential(UniCredential):
 		if basetype == asyauthSecret.CCACHE:
 			return KCRED.from_ccache(self.secret, self.username, self.domain, encoding=encoding)
 		if basetype == asyauthSecret.PFX:
-			return KCRED.from_pfx(self.keydata, self.secret, self.dh_params, self.altname, self.altdomain, encoding=encoding)
+			return KCRED.from_pfx(self.keydata, self.secret, self.dh_params, self.username, self.domain, encoding=encoding)
 		if basetype == asyauthSecret.PFXSTR:
-			return KCRED.from_pfx_string(self.keydata, self.secret, self.dh_params, self.altname, self.altdomain)
+			return KCRED.from_pfx_string(self.keydata, self.secret, self.dh_params, self.username, self.domain)
 
 		res = KCRED()
 		res.username = self.username

--- a/asyauth/protocols/spnego/client/native.py
+++ b/asyauth/protocols/spnego/client/native.py
@@ -103,7 +103,21 @@ class SPNEGOClientNative:
 		Context MUST be already set up!
 		"""
 		self.authentication_contexts[name] = ctx
-		self.original_authentication_contexts[name] = copy.deepcopy(ctx)
+		self.original_authentication_contexts[name] = self._deep_copy_context(ctx)
+
+	def _deep_copy_context(self, ctx):
+		"""
+		Create a deep copy of the context, excluding the RSAPrivateKey object which is not serializable.
+		"""
+		if hasattr(ctx, 'ccred') and hasattr(ctx.ccred, 'private_key'):
+			private_key = ctx.ccred.private_key
+			ctx.ccred.private_key = None
+			new_ctx = copy.deepcopy(ctx)
+			ctx.ccred.private_key = private_key
+			new_ctx.ccred.private_key = private_key
+		else:
+			new_ctx = copy.deepcopy(ctx)
+			return new_ctx
 		
 	def select_common_athentication_type(self, mech_types):
 		for auth_type_name in self.authentication_contexts:


### PR DESCRIPTION
Remove default etype overriding as minikerberos already has default etypes adapted to the type of credentials provided, also pkinit can fetch domain/username from cert so add an exception in the sanity check and adapt the deepcopy to the private key object which cannot be duplicated